### PR TITLE
Fix semantics label on month button

### DIFF
--- a/lib/src/widgets/_impl/_date_picker_mode_toggle_button.dart
+++ b/lib/src/widgets/_impl/_date_picker_mode_toggle_button.dart
@@ -83,7 +83,6 @@ class _DatePickerModeToggleButtonState
           Flexible(
             child: Semantics(
               label: MaterialLocalizations.of(context).selectYearSemanticsLabel,
-              excludeSemantics: true,
               button: true,
               child: SizedBox(
                 height: (widget.config.controlsHeight ?? _subHeaderHeight),


### PR DESCRIPTION
The fix is done, because the month button is not pronounced when voice over is turn on